### PR TITLE
Add token into service account import's secret

### DIFF
--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -279,7 +279,14 @@ func MakeServiceAccountImportSecret(sai *v1alpha1.ServiceAccountImport, server s
 		},
 	})
 	utilruntime.Must(err) // encoding errors should not happen
-	s.Data = map[string][]byte{"config": kubeconfig, "token": saSecret.Data["token"]}
+	s.Data = make(map[string][]byte, len(saSecret.Data) + 1)
+	for k, v := range saSecret.Data {
+		s.Data[k] = v
+	} // includes ca.crt, namespace, and token
+	s.Data["server"] = []byte(server)
+	// that should be enough information to call a remote Kubernetes API,
+	// but let's add the standard kubeconfig as a convenience
+	s.Data["config"] = kubeconfig
 
 	s.Labels = map[string]string{
 		AnnotationKeyServiceAccountImportName: string(sai.Name),

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -28,7 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -37,9 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var ctrlName = "service-account-import-controller"
@@ -279,11 +279,11 @@ func MakeServiceAccountImportSecret(sai *v1alpha1.ServiceAccountImport, server s
 		},
 	})
 	utilruntime.Must(err) // encoding errors should not happen
-	s.Data = map[string][]byte{"config": kubeconfig}
+	s.Data = map[string][]byte{"config": kubeconfig, "token": saSecret.Data["token"]}
 
 	s.Labels = map[string]string{
-		AnnotationKeyServiceAccountImportName:         string(sai.Name),
-		remoteSecretUID: string(s.UID),
+		AnnotationKeyServiceAccountImportName: string(sai.Name),
+		remoteSecretUID:                       string(s.UID),
 	}
 
 	return s


### PR DESCRIPTION
Signed-off-by: Alain Saint-Sever <asaintsever@talend.com>

In addition to the kubeconfig file, goal of this PR is to also expose the imported service account's token directly in its own file (`token`). This token is already part of the kubeconfig data but, for some use cases requiring submission of service account tokens (e.g. Hashicorp Vault's Kubernetes authentication using Vault Agent: https://www.vaultproject.io/docs/agent/autoauth/methods/kubernetes.html#token_path), it is not practical having to parse and extract this information from the kubeconfig yaml.